### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,17 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/udisks2-qt5.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/udisks2-qt5.spec
+    - .packit.yaml
+
+upstream_package_name: udisks2-qt5
+# downstream (Fedora) RPM package name
+downstream_package_name: udisks2-qt5
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/udisks2-qt5.spec"

--- a/rpm/udisks2-qt5.spec
+++ b/rpm/udisks2-qt5.spec
@@ -1,10 +1,14 @@
 Name:           udisks2-qt5
-Version:        5.0.0
-Release:        3%{?dist}
+Version:        5.0.5
+Release:        1%{?dist}
 Summary:        Qt5 binding for udisks2
 License:        GPLv3+
 URL:            https://github.com/linuxdeepin/udisks2-qt5
+%if 0%{?fedora}
+Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+%else
 Source0:        %{name}_%{version}.tar.gz
+%endif
 BuildRequires:  gcc-c++
 BuildRequires:  pkgconfig(Qt5Core)
 
@@ -20,7 +24,7 @@ Requires:       qt5-qtbase-devel%{?isa}
 Header files and libraries for %{name}.
 
 %prep
-%setup -q
+%autosetup -p1
 sed -i 's|/lib|/%{_lib}|' udisks2.pro
 
 %build
@@ -42,18 +46,3 @@ export PATH=%{_qt5_bindir}:$PATH
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
-* Wed Jul 29 2020 Fedora Release Engineering <releng@fedoraproject.org> - 5.0.0-3
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_33_Mass_Rebuild
-
-* Fri Jan 31 2020 Fedora Release Engineering <releng@fedoraproject.org> - 5.0.0-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_32_Mass_Rebuild
-
-* Mon Aug 05 2019 Robin Lee <cheeselee@fedoraproject.org> - 5.0.0-1
-- Release 5.0.0
-
-* Sat Jul 27 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.0.1-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
-
-* Thu Apr  4 2019 Robin Lee <cheeselee@fedoraproject.org> - 0.0.1-1
-- Initial packaging
-


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log:
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>